### PR TITLE
doc: remove >>>

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -10,11 +10,11 @@ Using the Python retry decorator
 
     >>> from python_retry import retry
     >>> import pytest
-    >>>
+
     >>> @retry()
     ... def div(num: int, den: int):
     ...     return num/den
-    >>>
+    
     >>> div(1, 0)
 
 
@@ -25,7 +25,7 @@ Advanced use
 
     >>> import logging
     >>> logger = logging.getLogger("foo")
-    >>>
+
     >>> @retry(
     ...     retry_on=(ZeroDivisionError,),
     ...     max_retries=2,
@@ -35,5 +35,5 @@ Advanced use
     ... )
     ... def div(num: int, den: int):
     ...     return num / den
-    >>>
+
     >>> div(1, 0)


### PR DESCRIPTION
These will be rendered wrong on readthedocs.

When you mark the code to copy, it will mark the `>>>` empty lines together with the regular code.

Now you'll only get the actual code.

Example with `>>>` marked:
![image](https://github.com/pyprogrammerblog/python-retry/assets/518090/ad46745c-11f2-40ce-85cd-b607238169f8)
